### PR TITLE
Fixed blurry fonts caused by automatic DPI scaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ target_precompile_headers(Nvy PUBLIC
     <d2d1_3.h>
     <d2d1_3helper.h>
     <dwrite_3.h>
+    <shellscalingapi.h>
+    <dwmapi.h>
     
     "src/third_party/mpack/mpack.h"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(Nvy PUBLIC
     d3d11.lib 
     d2d1.lib 
     dwrite.lib
+    Shcore.lib
 )
 
 target_precompile_headers(Nvy PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(Nvy PUBLIC
     d2d1.lib 
     dwrite.lib
     Shcore.lib
+    Dwmapi.lib
 )
 
 target_precompile_headers(Nvy PUBLIC

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,7 +278,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 }
 
 int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_line, int n_cmd_show) {
-	SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+	SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
 
 	int n_args;
 	LPWSTR *cmd_line_args = CommandLineToArgvW(GetCommandLineW(), &n_args);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,6 +121,16 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 			GetWindowRect(hwnd, &window_rect); // Window RECT with shadows
 			int new_window_width = (window_rect.right - window_rect.left) * dpiScale + 0.5f;
 			int new_window_height = (window_rect.bottom - window_rect.top) * dpiScale + 0.5f;
+
+			// Make sure window is not larger than the actual monitor
+			MONITORINFO MonitorInfo;
+			MonitorInfo.cbSize = sizeof(MonitorInfo);
+			GetMonitorInfo(monitor, &MonitorInfo);
+			uint32_t MonitorWidth = MonitorInfo.rcWork.right - MonitorInfo.rcWork.left;
+			uint32_t MonitorHeight = MonitorInfo.rcWork.bottom - MonitorInfo.rcWork.top;
+			if (new_window_width > MonitorWidth) new_window_width = MonitorWidth;
+			if (new_window_height > MonitorHeight) new_window_height = MonitorHeight;
+
 			SetWindowPos(hwnd, nullptr, 0, 0, new_window_width, new_window_height, SWP_NOMOVE | SWP_NOOWNERZORDER);
 			context->saved_dpi_scaling = current_dpi;
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,5 @@
 #include "nvim/nvim.h"
 #include "renderer/renderer.h"
-#include <shellscalingapi.h>
-#include <dwmapi.h>
 
 struct Context {
 	GridSize start_grid_size;
@@ -117,19 +115,19 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 		UINT current_dpi = 0;
 		GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &current_dpi, &current_dpi);
 		if (current_dpi != context->saved_dpi_scaling) {
-			float dpiScale = (float)current_dpi / (float)context->saved_dpi_scaling;
+			float dpi_scale = static_cast<float>(current_dpi) / static_cast<float>(context->saved_dpi_scaling);
 			GetWindowRect(hwnd, &window_rect); // Window RECT with shadows
-			int new_window_width = (window_rect.right - window_rect.left) * dpiScale + 0.5f;
-			int new_window_height = (window_rect.bottom - window_rect.top) * dpiScale + 0.5f;
+			int new_window_width = (window_rect.right - window_rect.left) * dpi_scale + 0.5f;
+			int new_window_height = (window_rect.bottom - window_rect.top) * dpi_scale + 0.5f;
 
 			// Make sure window is not larger than the actual monitor
-			MONITORINFO MonitorInfo;
-			MonitorInfo.cbSize = sizeof(MonitorInfo);
-			GetMonitorInfo(monitor, &MonitorInfo);
-			uint32_t MonitorWidth = MonitorInfo.rcWork.right - MonitorInfo.rcWork.left;
-			uint32_t MonitorHeight = MonitorInfo.rcWork.bottom - MonitorInfo.rcWork.top;
-			if (new_window_width > MonitorWidth) new_window_width = MonitorWidth;
-			if (new_window_height > MonitorHeight) new_window_height = MonitorHeight;
+			MONITORINFO monitor_info;
+			monitor_info.cbSize = sizeof(monitor_info);
+			GetMonitorInfo(monitor, &monitor_info);
+			uint32_t monitor_width = monitor_info.rcWork.right - monitor_info.rcWork.left;
+			uint32_t monitor_height = monitor_info.rcWork.bottom - monitor_info.rcWork.top;
+			if (new_window_width > monitor_width) new_window_width = monitor_width;
+			if (new_window_height > monitor_height) new_window_height = monitor_height;
 
 			SetWindowPos(hwnd, nullptr, 0, 0, new_window_width, new_window_height, SWP_NOMOVE | SWP_NOOWNERZORDER);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 
 			SetWindowPos(hwnd, nullptr, 0, 0, new_window_width, new_window_height, SWP_NOMOVE | SWP_NOOWNERZORDER);
 
-			RendererUpdateFont(context->renderer, context->renderer->last_requested_font_size * dpiScale);
+			context->renderer->dpi_scale = current_dpi / 96.0f;
+			RendererUpdateFont(context->renderer, context->renderer->last_requested_font_size);
 			auto [rows, cols] = RendererPixelsToGridSize(context->renderer,
 				context->renderer->pixel_size.width, context->renderer->pixel_size.height);
 			if (rows != context->renderer->grid_rows || cols != context->renderer->grid_cols) {

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -164,12 +164,12 @@ void HandleDeviceLost(Renderer *renderer) {
 	);
 }
 
-void RendererInitialize(Renderer *renderer, HWND hwnd, bool disable_ligatures, float linespace_factor) {
+void RendererInitialize(Renderer *renderer, HWND hwnd, bool disable_ligatures, float linespace_factor, float monitor_dpi) {
 	renderer->hwnd = hwnd;
 	renderer->disable_ligatures = disable_ligatures;
 	renderer->linespace_factor = linespace_factor;
 
-	renderer->dpi_scale = GetDpiForSystem() / 96.0f;
+	renderer->dpi_scale = monitor_dpi / 96.0f;
     renderer->hl_attribs.resize(MAX_HIGHLIGHT_ATTRIBS);
 
 	InitializeD2D(renderer);

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -110,7 +110,7 @@ struct Renderer {
 	bool ui_busy;
 };
 
-void RendererInitialize(Renderer *renderer, HWND hwnd, bool disable_ligatures, float linespace_factor);
+void RendererInitialize(Renderer *renderer, HWND hwnd, bool disable_ligatures, float linespace_factor, float monitor_dpi);
 void RendererAttach(Renderer *renderer);
 void RendererShutdown(Renderer *renderer);
 


### PR DESCRIPTION
Windows automatically scales the application when you move the window between monitors with different DPI scaling settings (I tested moving from a monitor with 125% scaling to 100% scaling). This often causes the fonts to look blurry. The change I made fixes this by telling Windows not to auto-resize the window when moving it between monitors with different DPI settings (first line in WinMain). Instead, NVY now manually adjusts the window size and dpi_scale in the renderer on the WM_MOVE event.

Anyways, this project is really cool and let me know if this PR needs improvements :)