### PR TITLE
Fix drag and drop for non ascii file path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -301,10 +301,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 		}
 	} return 0;
 	case WM_DROPFILES: {
-		char file_to_open[MAX_PATH];
-		uint32_t num_files = DragQueryFileA(reinterpret_cast<HDROP>(wparam), 0xFFFFFFFF, file_to_open, MAX_PATH);
+		wchar_t file_to_open[MAX_PATH];
+		uint32_t num_files = DragQueryFileW(reinterpret_cast<HDROP>(wparam), 0xFFFFFFFF, file_to_open, MAX_PATH);
 		for(int i = 0; i < num_files; ++i) {
-			DragQueryFileA(reinterpret_cast<HDROP>(wparam), i, file_to_open, MAX_PATH);
+			DragQueryFileW(reinterpret_cast<HDROP>(wparam), i, file_to_open, MAX_PATH);
 			NvimOpenFile(context->nvim, file_to_open);
 		}
 	} return 0;

--- a/src/nvim/nvim.cpp
+++ b/src/nvim/nvim.cpp
@@ -567,9 +567,6 @@ bool NvimProcessKeyDown(Nvim *nvim, int virtual_key) {
 void NvimOpenFile(Nvim *nvim, const wchar_t *file_name) {
 
 	char utf8_encoded[MAX_PATH]{};
-	//if(!WideCharToMultiByte(CP_UTF8, 0, file_name, 1, 0, 0, NULL, NULL)) {
-    //	return;
-	//}
 	WideCharToMultiByte(CP_UTF8, 0, file_name, -1, utf8_encoded, MAX_PATH, NULL, NULL);
 
 	char file_command[MAX_PATH + 2] = {};

--- a/src/nvim/nvim.cpp
+++ b/src/nvim/nvim.cpp
@@ -564,10 +564,17 @@ bool NvimProcessKeyDown(Nvim *nvim, int virtual_key) {
 	return true;
 }
 
-void NvimOpenFile(Nvim *nvim, const char *file_name) {
+void NvimOpenFile(Nvim *nvim, const wchar_t *file_name) {
+
+	char utf8_encoded[MAX_PATH]{};
+	//if(!WideCharToMultiByte(CP_UTF8, 0, file_name, 1, 0, 0, NULL, NULL)) {
+    //	return;
+	//}
+	WideCharToMultiByte(CP_UTF8, 0, file_name, -1, utf8_encoded, MAX_PATH, NULL, NULL);
+
 	char file_command[MAX_PATH + 2] = {};
 	strcpy_s(file_command, MAX_PATH, "e ");
-	strcat_s(file_command, MAX_PATH - 3, file_name);
+	strcat_s(file_command, MAX_PATH - 3, utf8_encoded);
 
 	char data[MAX_MPACK_OUTBOUND_MESSAGE_SIZE];
 	mpack_writer_t writer;

--- a/src/nvim/nvim.h
+++ b/src/nvim/nvim.h
@@ -66,4 +66,4 @@ void NvimSendInput(Nvim *nvim, const char* input_chars);
 void NvimSendInput(Nvim *nvim, int virtual_key, int flags);
 void NvimSendMouseInput(Nvim *nvim, MouseButton button, MouseAction action, int mouse_row, int mouse_col);
 bool NvimProcessKeyDown(Nvim *nvim, int virtual_key);
-void NvimOpenFile(Nvim *nvim, const char *file_name);
+void NvimOpenFile(Nvim *nvim, const wchar_t *file_name);


### PR DESCRIPTION
This PR is to address this bug:  #34  "Drag and drop does not work with cyrillic characters in path or filename"