### PR TITLE
Fix IME window position issue #23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(Nvy PUBLIC
     dwrite.lib
     Shcore.lib
     Dwmapi.lib
+    imm32.lib
 )
 
 target_precompile_headers(Nvy PUBLIC
@@ -56,6 +57,7 @@ target_precompile_headers(Nvy PUBLIC
     <dwrite_3.h>
     <shellscalingapi.h>
     <dwmapi.h>
+    <imm.h>
     
     "src/third_party/mpack/mpack.h"
 


### PR DESCRIPTION
This PR is to address this bug: #23

The Input Method Manager (IMM) needs to report after the cursor changes position, to update the position of the IME window.

The IMM is only enabled on East Asian (Chinese, Japanese, Korean) localized Windows systems.
I don’t know how it will work on Windows with IMM disabled. I don't have the environment, please test it before merging.