### PR TITLE
Support `:cq`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,5 +443,5 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 	UnregisterClass(window_class_name, instance);
 	DestroyWindow(hwnd);
 
-	return 0;
+	return nvim.exit_code;
 }

--- a/src/nvim/nvim.cpp
+++ b/src/nvim/nvim.cpp
@@ -50,6 +50,7 @@ DWORD WINAPI NvimProcessMonitor(LPVOID param) {
 			Sleep(1);
 		}
 		else {
+			nvim->exit_code = exit_code;
 			break;
 		}
 	}

--- a/src/nvim/nvim.h
+++ b/src/nvim/nvim.h
@@ -51,6 +51,7 @@ struct Nvim {
 	HANDLE stdout_read;
 	HANDLE stdout_write;
 	PROCESS_INFORMATION process_info;
+	DWORD exit_code;
 };
 
 void NvimInitialize(Nvim *nvim, wchar_t *command_line, HWND hwnd);


### PR DESCRIPTION
Terminal Neovim and Neovim-qt has support for `:{N}cq`, which quits the Neovim with error code {N}. This feature is useful in applications which uses editor as a user interface --- especially git. For example, it can safely abort `git commit` during editing commit message, since git aborts committing if editor returns non-zero exit code. You can abort a commit by simply typing `:q!` without saving commit message, but `:cq` is safer in a sense that it will abort the commit message even if you unintentionally save it while editing. Same goes for `git rebase -i` and many other git commands.
