### PR TITLE
Check cursor mode before drawing

### DIFF
--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -629,6 +629,7 @@ void DrawGridLines(Renderer *renderer, mpack_node_t grid_lines) {
 }
 
 void DrawCursor(Renderer *renderer) {
+	if (!renderer->cursor.mode_info) return;
 	int cursor_grid_offset = renderer->cursor.row * renderer->grid_cols + renderer->cursor.col;
 
 	int double_width_char_factor = 1;


### PR DESCRIPTION
With newer version of Neovim, Nvy sometimes crashes on startup. More accurately, Nvy always crashes with one of my vimrc, but never crashes with my another vimrc. There seems to be something related to this issue in my configuration. However, the direct cause of this crash is that in that case `DrawCursor()` accesses to the `renderer->cursor.mode_info` before it is set, resulting in NULL dereference. Checking that variable is non-NULL fixed the issue. 

I'm still not sure the exact factor causing this, maybe it is a bug on Neovim, but I think this is a harmless change, so I opened this PR.