### PR TITLE
Inherit GUI options for character under cursor

### DIFF
--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -638,6 +638,12 @@ void DrawCursor(Renderer *renderer) {
 	}
 
 	HighlightAttributes cursor_hl_attribs = renderer->hl_attribs[renderer->cursor.mode_info->hl_attrib_id];
+
+	// Inherit GUI options for char under cursor (like italic)
+	int hl_attrib_id_under_cursor = renderer->grid_cell_properties[cursor_grid_offset].hl_attrib_id;
+	HighlightAttributes under_cursor_hl_attribs = renderer->hl_attribs[hl_attrib_id_under_cursor];
+	cursor_hl_attribs.flags = under_cursor_hl_attribs.flags;
+
 	if (renderer->cursor.mode_info->hl_attrib_id == 0) {
 		cursor_hl_attribs.flags ^= HL_ATTRIB_REVERSE;
 	}


### PR DESCRIPTION
Font attributes (Italic, bold, underlines, etc.) for a character under cursor should be respected even if it's not specified on the cursor highlight itself.

Before:

![image](https://user-images.githubusercontent.com/20490597/177042997-3f2be03f-117c-4d5d-b5f0-0072285e5e14.png)

After:

![image](https://user-images.githubusercontent.com/20490597/177042998-1d4489d0-8b72-432d-abc6-d7d3038e6b8c.png)
