### PR TITLE
Fix latency, including fullscreen mode

### DIFF
--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -948,7 +948,7 @@ void CopyFrontToBack(Renderer *renderer) {
 void FinishDraw(Renderer *renderer) {
 	renderer->d2d_context->EndDraw();
 
-	HRESULT hr = renderer->dxgi_swapchain->Present(0, 0);
+	HRESULT hr = renderer->dxgi_swapchain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
 	renderer->draw_active = false;
 
 	CopyFrontToBack(renderer);


### PR DESCRIPTION
In my environment, `WaitForSingleObjectEx(swapchain_wait_handle)` takes 15ms for almost every call as if it is trying to keep 60Hz (this is refresh rate of the computer), especially when continuously scrolling like #45. With `DXGI_PRESENT_ALLOW_TEARING` flag, those lags disappeared. I'm not familiar with DirectX, so I'm not sure what `DXGI_PRESENT_ALLOW_TEARING` means, but from the appearance of name it may disable some wait at the cost of allowing tearings. Note that indeed I see some tearing with this patch. I think quick response is way better than no tearings with terrible slowdown though...

PR is done, but I'll try using this to check this works for a while, so open it as draft PR for now.

Fixes #45, Fixes #46.
