### PR TITLE
Fix #73 white flash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -396,8 +396,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 
 	const wchar_t *window_class_name = L"Nvy_Class";
 	const wchar_t *window_title = L"Nvy";
-	BOOL should_use_dark_mode = ShouldUseDarkMode();
-	HBRUSH bg_brush = CreateSolidBrush(should_use_dark_mode ? 0x00202020 : 0x00FFFFFF);
+	HBRUSH bg_brush = (HBRUSH)GetStockObject(BLACK_BRUSH);
 	WNDCLASSEX window_class {
 		.cbSize = sizeof(WNDCLASSEX),
 		.style = CS_HREDRAW | CS_VREDRAW,
@@ -449,6 +448,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 	HMONITOR monitor = MonitorFromPoint({window_rect.left, window_rect.top}, MONITOR_DEFAULTTONEAREST);
 	GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &(context.saved_dpi_scaling), &(context.saved_dpi_scaling));
 	constexpr int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+	BOOL should_use_dark_mode = ShouldUseDarkMode();
 	DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &should_use_dark_mode, sizeof(BOOL));
 	RendererInitialize(&renderer, hwnd, disable_ligatures, linespace_factor, context.saved_dpi_scaling);
 	NvimInitialize(&nvim, nvim_command_line, hwnd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,7 +402,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 
 	const wchar_t *window_class_name = L"Nvy_Class";
 	const wchar_t *window_title = L"Nvy";
-	HBRUSH bg_brush = (HBRUSH)GetStockObject(BLACK_BRUSH);
+	HBRUSH bg_brush = (HBRUSH)GetStockObject(HOLLOW_BRUSH);
 	WNDCLASSEX window_class {
 		.cbSize = sizeof(WNDCLASSEX),
 		.style = CS_HREDRAW | CS_VREDRAW,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -452,7 +452,10 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 	DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &should_use_dark_mode, sizeof(BOOL));
 	RendererInitialize(&renderer, hwnd, disable_ligatures, linespace_factor, context.saved_dpi_scaling);
 	NvimInitialize(&nvim, nvim_command_line, hwnd);
-	
+	// Forceably update the window to prevent any frames where the window is blank. Windows API docs
+	// specify that SetWindowPos should be called with these arguments after SetWindowLong is called.
+	SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
 	MSG msg;
 	uint32_t previous_width = 0, previous_height = 0;
 	while (GetMessage(&msg, 0, 0, 0)) {

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -750,6 +750,8 @@ void UpdateGridSize(Renderer *renderer, mpack_node_t grid_resize) {
 			renderer->grid_chars[i] = L' ';
 		}
 		renderer->grid_cell_properties = static_cast<CellProperty *>(calloc(static_cast<size_t>(grid_cols) * grid_rows, sizeof(CellProperty)));
+
+		renderer->grid_initialized = true;
 	}
 }
 

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -593,6 +593,12 @@ void DrawGridLine(Renderer *renderer, int row) {
 	text_layout->Release();
 }
 
+void DrawAllGridLines(Renderer *renderer) {
+	for (size_t i = 0; i < renderer->grid_rows; ++i) {
+		DrawGridLine(renderer, i);
+	}
+}
+
 bool IsSurrogatePair(wchar_t left, wchar_t right) {
 	return (0xD800 <= left && left <= 0xDBFF) && (0xDC00 <= right && right <= 0xDFFF);
 }
@@ -1059,9 +1065,7 @@ void RendererRedraw(Renderer *renderer, mpack_node_t params) {
 		}
 		else if (MPackMatchString(redraw_command_name, "default_colors_set")) {
 			UpdateDefaultColors(renderer, redraw_command_arr);
-			for (size_t i = 0; i < renderer->grid_rows; ++i) {
-				DrawGridLine(renderer, i);
-			}
+			DrawAllGridLines(renderer);
 		}
 		else if (MPackMatchString(redraw_command_name, "hl_attr_define")) {
 			UpdateHighlightAttributes(renderer, redraw_command_arr);
@@ -1105,11 +1109,15 @@ void RendererRedraw(Renderer *renderer, mpack_node_t params) {
 			ScrollRegion(renderer, redraw_command_arr);
 		}
 		else if (MPackMatchString(redraw_command_name, "flush")) {
+			if (renderer->draws == 1) {
+				DrawAllGridLines(renderer);
+			}
 			if(!renderer->ui_busy) {
 				DrawCursor(renderer);
 			}
 			DrawBorderRectangles(renderer);
 			FinishDraw(renderer);
+			++renderer->draws;
 		}
 	}
 }

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -1109,14 +1109,20 @@ void RendererRedraw(Renderer *renderer, mpack_node_t params) {
 			ScrollRegion(renderer, redraw_command_arr);
 		}
 		else if (MPackMatchString(redraw_command_name, "flush")) {
-			if (renderer->draws == 1) {
+			if (renderer->draws == 0) {
+				ShowWindow(renderer->hwnd, SW_SHOWDEFAULT);
+			} else if (renderer->draws == 1) {
+				// On the first update all previous lines will get
+				// cleared, so redraw them so that they don't disappear.
 				DrawAllGridLines(renderer);
 			}
+
 			if(!renderer->ui_busy) {
 				DrawCursor(renderer);
 			}
 			DrawBorderRectangles(renderer);
 			FinishDraw(renderer);
+
 			++renderer->draws;
 		}
 	}

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -1059,6 +1059,9 @@ void RendererRedraw(Renderer *renderer, mpack_node_t params) {
 		}
 		else if (MPackMatchString(redraw_command_name, "default_colors_set")) {
 			UpdateDefaultColors(renderer, redraw_command_arr);
+			for (size_t i = 0; i < renderer->grid_rows; ++i) {
+				DrawGridLine(renderer, i);
+			}
 		}
 		else if (MPackMatchString(redraw_command_name, "hl_attr_define")) {
 			UpdateHighlightAttributes(renderer, redraw_command_arr);

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -111,7 +111,8 @@ struct Renderer {
 	HWND hwnd;
 	bool draw_active;
 	bool ui_busy;
-	int draws;
+	bool has_drawn;
+	bool draws_invalidated;
 };
 
 void RendererInitialize(Renderer *renderer, HWND hwnd, bool disable_ligatures, float linespace_factor, float monitor_dpi);

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -111,6 +111,7 @@ struct Renderer {
 	HWND hwnd;
 	bool draw_active;
 	bool ui_busy;
+	int draws;
 };
 
 void RendererInitialize(Renderer *renderer, HWND hwnd, bool disable_ligatures, float linespace_factor, float monitor_dpi);

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -102,6 +102,7 @@ struct Renderer {
     float font_descent;
 
 	D2D1_SIZE_U pixel_size;
+	bool grid_initialized;
 	int grid_rows;
 	int grid_cols;
 	wchar_t *grid_chars;


### PR DESCRIPTION
This pull request fixes #73 by consistently updating the WindowLongPtr after a window is created. The window background used to also default to white when the user's desktop was in light mode, now it always defaults to black which looks less jarring.