### PR TITLE
Maximize, fullscreen, and position flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Note: you have to specify the font size, e.g. `set guifont=Fira\ Code` won't wor
 A fallback font can be specified by appending it, e.g. `set guifont=Fira\ Code:h24:Consolas` to set Consolas as the fallback font.
 
 Nvy can be started with the following flags:
-- `--maximize` to start in fullscreen
+- `--maximize` to start in maximized
+- `--fullscreen` to start in fullscreen
 - `--geometry=<cols>x<rows>` to start with a given number of rows and columns, e.g. `--geometry=80x25`
 - `--disable-ligatures` to disable font ligatures
 - `--linespace-factor=<float>` to scale the line spacing by a floating point factor, e.g. `--linespace-factor=1.2`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A fallback font can be specified by appending it, e.g. `set guifont=Fira\ Code:h
 Nvy can be started with the following flags:
 - `--maximize` to start in maximized
 - `--fullscreen` to start in fullscreen
+- `--position=<x>,<y>` to start with a given position, e.g. `--position=500,200`
 - `--geometry=<cols>x<rows>` to start with a given number of rows and columns, e.g. `--geometry=80x25`
 - `--disable-ligatures` to disable font ligatures
 - `--linespace-factor=<float>` to scale the line spacing by a floating point factor, e.g. `--linespace-factor=1.2`

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 struct Context {
 	GridSize start_grid_size;
 	bool start_maximized;
+	bool start_fullscreen;
 	HWND hwnd;
 	Nvim *nvim;
 	Renderer *renderer;
@@ -74,10 +75,10 @@ void ProcessMPackMessage(Context *context, mpack_tree_t *tree) {
 				context->renderer->pixel_size.width, context->renderer->pixel_size.height);
 			NvimSendUIAttach(context->nvim, rows, cols);
 
-			if (context->start_maximized) {
+			if (context->start_fullscreen) {
 				ToggleFullscreen(context->hwnd, context);
 			}
-			ShowWindow(context->hwnd, SW_SHOWDEFAULT);
+			ShowWindow(context->hwnd, context->start_maximized ? SW_MAXIMIZE : SW_SHOWDEFAULT);
 		} break;
         case NvimRequest::nvim_input:
         case NvimRequest::nvim_input_mouse:
@@ -349,6 +350,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 	int n_args;
 	LPWSTR *cmd_line_args = CommandLineToArgvW(GetCommandLineW(), &n_args);
 	bool start_maximized = false;
+	bool start_fullscreen = false;
 	bool disable_ligatures = false;
 	float linespace_factor = 1.0f;
 	int64_t rows = 0;
@@ -364,6 +366,9 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 	for(int i = 1; i < n_args; ++i) {
 		if(!wcscmp(cmd_line_args[i], L"--maximize")) {
 			start_maximized = true;
+		}
+		else if(!wcscmp(cmd_line_args[i], L"--fullscreen")) {
+			start_fullscreen = true;
 		}
 		else if(!wcscmp(cmd_line_args[i], L"--disable-ligatures")) {
 			disable_ligatures = true;
@@ -422,6 +427,7 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, PWSTR p_cmd_lin
 			.cols = static_cast<int>(cols)
 		},
 		.start_maximized = start_maximized,
+		.start_fullscreen = start_fullscreen,
 
 		.nvim = &nvim,
 		.renderer = &renderer,


### PR DESCRIPTION
I would like to have Nvy maximized on start, but the `--maximize` flag makes it fullscreen, so I changed `--maximize` to maximize, and added `--fullscreen` for fullscreen. I also added `--position` flag for #65.
This will change how the maximize flag previously worked, and perhaps the position flag could merge with the geometry flag like `nvim-qt` e.g. `--geometry=<width>x<height>+<x>+<y>` (though I prefer the position flag), so I'd like to hear some inputs.