### PR TITLE
Create a version-information resource file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(Nvy)
-add_executable(Nvy WIN32 "resources/third_party/nvim_icon.rc")
+add_executable(Nvy WIN32 "resources/third_party/nvim_icon.rc" version_info.rc)
 
 set(Nvy_HEADERS
     "src/common/dx_helper.h"
@@ -83,3 +83,46 @@ if(MSVC)
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
 endif()
+
+## Configure a rc file to include version numbers
+find_package(Git)
+
+if(GIT_EXECUTABLE)
+    # Generate a git-describe version string from Git repository tags
+    execute_process(
+	COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+	OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+	RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+endif()
+
+# Split a version number into separate components
+string(REGEX MATCH "v([0-9]+)\.([0-9]+)\.([0-9]+)(.*)?" VERSION_VALID ${GIT_DESCRIBE_VERSION})
+if(VERSION_VALID)
+    string(REGEX REPLACE "v([0-9]+)\.([0-9]+)\.([0-9]+)\-?([0-9]+)?(.*)?" "\\1;\\2;\\3;\\4;\\5" RESULT_MATCHES ${GIT_DESCRIBE_VERSION})
+    list(GET RESULT_MATCHES 0 VERSION_MAJOR)
+    list(GET RESULT_MATCHES 1 VERSION_MINOR)
+    list(GET RESULT_MATCHES 2 VERSION_PATCH)
+    list(GET RESULT_MATCHES 3 VERSION_EXTRA)
+    list(GET RESULT_MATCHES 4 COMMIT)
+else()
+    message(AUTHOR_WARNING "Bad version ${GIT_DESCRIBE_VERSION}; falling back to 0 (have you made an initial release?)")
+    set(${VERSION_MAJOR} "0" PARENT_SCOPE)
+    set(${VERSION_MINOR} "0" PARENT_SCOPE)
+    set(${VERSION_PATCH} "0" PARENT_SCOPE)
+    set(${VERSION_EXTRA} "0" PARENT_SCOPE)
+    set(${COMMIT} "local" PARENT_SCOPE)
+endif()
+
+set(PRODUCT_VERSION ${VERSION_MAJOR},${VERSION_MINOR},${VERSION_PATCH},${VERSION_EXTRA})
+set(FILE_VERSION ${VERSION_MAJOR},${VERSION_MINOR},${VERSION_PATCH},${VERSION_EXTRA})
+
+set(PRODUCT_VERSION_TEXT "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_EXTRA}${COMMIT}")
+set(FILE_VERSION_TEXT "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${VERSION_EXTRA}${COMMIT}")
+
+configure_file(
+  resources/version_info.rc.in
+  version_info.rc
+  @ONLY)

--- a/resources/version_info.rc.in
+++ b/resources/version_info.rc.in
@@ -1,0 +1,43 @@
+#include <winresrc.h>
+
+#define VER_FILE_VERSION @FILE_VERSION@
+#define VER_FILE_VERSION_STR "@FILE_VERSION_TEXT@\0"
+#define VER_PRODUCT_VERSION @PRODUCT_VERSION@
+#define VER_PRODUCT_VERSION_STR "@PRODUCT_VERSION_TEXT@\0"
+
+// Executable version information.
+
+VS_VERSION_INFO    VERSIONINFO
+FILEVERSION        VER_FILE_VERSION
+PRODUCTVERSION     VER_PRODUCT_VERSION
+FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+  FILEFLAGS        VS_FF_DEBUG
+#else
+  FILEFLAGS        0
+#endif
+FILEOS             VOS_NT_WINDOWS32
+FILETYPE           VFT_APP
+FILESUBTYPE        VFT2_UNKNOWN
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    // 0x0409 == U.S. English; 0x04E4 => Windows Multilingual
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "CompanyName",      "Rasmus Ishøy Michelsen and collaborators\0"
+      VALUE "FileDescription",  "Nvy.exe\0"
+      VALUE "FileVersion",      VER_FILE_VERSION_STR
+      VALUE "InternalName",     "Nvy\0"
+      VALUE "LegalCopyright",   "MIT License © 2020 Rasmus Ishøy Michelsen\0"
+      VALUE "LegalTrademarks",  "https://github.com/RMichelsen/Nvy/\0"
+      VALUE "OriginalFilename", "Nvy.exe\0"
+      VALUE "ProductName",      "Nvy - A Neovim client in C++\0"
+      VALUE "ProductVersion",   VER_PRODUCT_VERSION_STR
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation",  0x409, 0x4E4
+  END
+END


### PR DESCRIPTION
Get version information from git tag if available

Tag name must be vX.Y.Z

This fills the properties in the details tab of Nvy.exe

![Nvy_properties](https://user-images.githubusercontent.com/5230787/232323888-530097ac-8e4b-4fc5-8cae-5270d2d15c35.png)
