### PR TITLE
Always reverse colors when hl_attrib_id is 0

### DIFF
--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -728,7 +728,7 @@ void DrawCursor(Renderer *renderer) {
 	cursor_hl_attribs.flags = under_cursor_hl_attribs.flags;
 
 	if (renderer->cursor.mode_info->hl_attrib_id == 0) {
-		cursor_hl_attribs.flags ^= HL_ATTRIB_REVERSE;
+		cursor_hl_attribs.flags |= HL_ATTRIB_REVERSE;
 	}
 
 	D2D1_RECT_F cursor_rect {


### PR DESCRIPTION
The [spec](https://neovim.io/doc/user/ui.html ) says that "When attr_id is 0, the background and foreground colors should be swapped". Previously this was only happening some of the time, breaking highlighting in rare cases. For example, on the built in `habamax` theme, when highlighting matching braces the cursor would seem to disappear.

Before this commit:
![image](https://github.com/RMichelsen/Nvy/assets/70043176/58f37251-b5d0-4917-93ad-49e8e9bc1e9c)

After this commit:
![image](https://github.com/RMichelsen/Nvy/assets/70043176/e4592d0d-6ec0-403e-ade8-f81fef1a0328)
