### PR TITLE
Fix text moving into non-client area

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,7 +464,7 @@ int WINAPI wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev_instance, _
 	};
 
 	HWND hwnd = CreateWindowEx(
-		WS_EX_ACCEPTFILES,
+		WS_EX_ACCEPTFILES | WS_EX_NOREDIRECTIONBITMAP,
 		window_class_name,
 		window_title,
 		WS_OVERLAPPEDWINDOW,


### PR DESCRIPTION
When changing resolution or adding an external monitor, Windows makes the bitmap move "under" the non-client area.
This can be seen as the following:

![imagen](https://github.com/RMichelsen/Nvy/assets/2888452/c8c659d5-837f-4b18-9499-7b993458b798)

It fixes when the Nvy window is moved.

The code fixes this by telling Windows not to mess with Nvy window content.

