### PR TITLE
Fix moving window to different DPI screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,16 +118,19 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 		RECT* const prcNewWindow = (RECT*)lparam;
 
 		context->renderer->dpi_scale = current_dpi / 96.0f;
-		RendererUpdateFont(context->renderer, context->renderer->last_requested_font_size);
-		auto [rows, cols] = RendererPixelsToGridSize(context->renderer,
-				prcNewWindow->right - prcNewWindow->left, prcNewWindow->bottom - prcNewWindow->top);
-		SendResizeIfNecessary(context, rows, cols);
+		context->saved_window_width = prcNewWindow->right - prcNewWindow->left;
+		context->saved_window_height = prcNewWindow->bottom - prcNewWindow->top;
 		context->saved_dpi_scaling = current_dpi;
+		RendererUpdateFont(context->renderer, context->renderer->last_requested_font_size);
 
 		SetWindowPos(hwnd, NULL,
-				0, 0,
+				prcNewWindow->left, prcNewWindow->top,
 				prcNewWindow->right - prcNewWindow->left, prcNewWindow->bottom - prcNewWindow->top,
-				SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+				SWP_NOZORDER | SWP_NOACTIVATE);
+
+		RendererResize(context->renderer, context->saved_window_width, context->saved_window_height);
+		auto [rows, cols] = RendererPixelsToGridSize(context->renderer, context->saved_window_width, context->saved_window_height);
+		SendResizeIfNecessary(context, rows, cols);
 	} return 0;
 	case WM_DESTROY: {
 		PostQuitMessage(0);


### PR DESCRIPTION
The previous behavior was pretty wild for me. When moving from a 100% scale display to a 150% scale display, the window would resize incorrectly, end up back on the 100% display, then as you continued to drag your mouse, it would trigger WM_DPICHANGED again and this would repeat a couple of times, often ending up with a window 4 or 8 times bigger than expected.

It's a bit hard to explain. I can provide a video if further clarification is needed.

I fixed this by using prcNewWindow->left/top (the new suggested window position from the event) instead of SWP_NOMOVE.

I also fixed the renderer not updating properly when a DPI transition happened, which would sometimes result in a wrong text scale.