### PR TITLE
Fix: window doesn't resize after `set lines`, `set columns`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,12 +88,14 @@ void ProcessMPackMessage(Context *context, mpack_tree_t *tree) {
 	}
 }
 
-void SendResizeIfNecessary(Context *context, int rows, int cols) {
-	if (!context->renderer->grid_initialized) return;
+bool SendResizeIfNecessary(Context *context, int rows, int cols) {
+	if (!context->renderer->grid_initialized) return false;
 
 	if (rows != context->renderer->grid_rows || cols != context->renderer->grid_cols) {
 		NvimSendResize(context->nvim, rows, cols);
+		return true;
 	}
+	return false;
 }
 
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
@@ -543,7 +545,8 @@ int WINAPI wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev_instance, _
 			previous_height = context.saved_window_height;
 			auto [rows, cols] = RendererPixelsToGridSize(context.renderer, context.saved_window_width, context.saved_window_height);
 			RendererResize(context.renderer, context.saved_window_width, context.saved_window_height);
-			SendResizeIfNecessary(&context, rows, cols);
+			if (!SendResizeIfNecessary(&context, rows, cols))
+				RendererFlush(context.renderer);
 		}
 	}
 

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -125,6 +125,7 @@ void RendererResize(Renderer *renderer, uint32_t width, uint32_t height);
 bool RendererUpdateGuiFont(Renderer *renderer, const char *guifont, size_t strlen);
 bool RendererUpdateFont(Renderer *renderer, float font_size, const char *font_string = "", int strlen = 0);
 void RendererRedraw(Renderer *renderer, mpack_node_t params, bool start_maximized);
+void RendererFlush(Renderer* renderer);
 
 PixelSize RendererGridToPixelSize(Renderer *renderer, int rows, int cols);
 GridSize RendererPixelsToGridSize(Renderer *renderer, int width, int height);


### PR DESCRIPTION
Detect a grid change and resize the (win32) window.  Neovim might not send a flush so manually force a full grid redraw.