### PR TITLE
Change window exit command to 'confirm qa'

### DIFF
--- a/src/nvim/nvim.cpp
+++ b/src/nvim/nvim.cpp
@@ -630,7 +630,7 @@ void NvimKillFocus(Nvim *nvim) {
 }
 void NvimQuit(Nvim *nvim)
 {
-	const char *quit_command = "qa";
+	const char *quit_command = "confirm qa";
 
 	char data[MAX_MPACK_OUTBOUND_MESSAGE_SIZE];
 	mpack_writer_t writer;


### PR DESCRIPTION
Currently, when attempting to close Nvy through Windows (Close Button, `Alt-F4`, etc.), it sends the command `qa` to Neovim. This command works fine when there are no unsaved changes, but if there are, it is completely useless: it will neither cause vim to force the exit (as it should not) or cause it to ask the user if the changes should be saved (as it should). The command line will simply say 'Press ENTER or type command to continue', leaving the user actually one step further away from exiting the program, now having to press ENTER and then quitting through another method.
A better way would be to send `confirm qa`. This will cause Neovim to ask the user, whether the changes should be saved or not. The user can then press `y`, `n` or `c` for `yes`, `no` or `cancel`.
I think this is much more intuitive and convenient, but at least allows the user to actually exit through the window close event if there are unsaved changes. If there are no unsaved changes, Neovim will obviously exit the same way as with `qa`.